### PR TITLE
Fix fwupdate_stat_status enum in OpenAPI schema

### DIFF
--- a/workdir/openapi.yaml
+++ b/workdir/openapi.yaml
@@ -68023,11 +68023,12 @@ components:
           type: boolean
       type: object
     fwupdate_stat_status:
-      description: 'enum: `inprogress`, `failed`, `upgraded`'
+      description: 'enum: `inprogress`, `failed`, `upgraded`, `success`'
       enum:
       - inprogress
       - failed
       - upgraded
+      - success
       nullable: true
       readOnly: true
       type: string


### PR DESCRIPTION
The fwupdate_stat enum definition was missing a value with its referenced type.

This resolves a schema inconsistency when using
GET /api/v1/sites/<site_id>/devices/<device_id> endpoints.