### PR TITLE
Extend dot11_bandwidth schemas for responses.

### DIFF
--- a/workdir/openapi.yaml
+++ b/workdir/openapi.yaml
@@ -66976,8 +66976,9 @@ components:
       type: string
     dot11_bandwidth:
       description: 'channel width for the band.enum: `20`, `40`, `80` (only applicable
-        for band_5 and band_6), `160` (only for band_6)'
+        for band_5 and band_6), `160` (only for band_6). `0` in responses only (i.e. for disabled)'
       enum:
+      - 0
       - 20
       - 40
       - 80
@@ -66986,16 +66987,18 @@ components:
       type: integer
     dot11_bandwidth24:
       default: 20
-      description: 'channel width for the 2.4GHz band. enum: `20`, `40`'
+      description: 'channel width for the 2.4GHz band. enum: `20`, `40`. `0` in responses only (i.e. for disabled)'
       enum:
+      - 0
       - 20
       - 40
       example: 20
       type: integer
     dot11_bandwidth5:
       default: 40
-      description: 'channel width for the 5GHz band. enum: `20`, `40`, `80`'
+      description: 'channel width for the 5GHz band. enum: `20`, `40`, `80`. `0` in responses only (i.e. for disabled)'
       enum:
+      - 0
       - 20
       - 40
       - 80
@@ -67003,13 +67006,14 @@ components:
       type: integer
     dot11_bandwidth6:
       default: 80
-      description: 'channel width for the 6GHz band. enum: `20`, `40`, `80`, `160`'
+      description: 'channel width for the 6GHz band. enum: `20`, `40`, `80`, `160`. `0` in responses only (i.e. for disabled)'
       enum:
+      - 0
       - 20
       - 40
       - 80
       - 160
-      example: 20
+      example: 80
       type: integer
     dot11_proto:
       description: 'enum: `a`, `ac`, `ax`, `b`, `g`, `n`'


### PR DESCRIPTION
Example:
        "band_24": {
            "num_clients": 0,
            "num_wlans": 0,
            "channel": 1,
            "bandwidth": 0, // Now allowed for a response
            "power": 0,
            "tx_bytes": 0,
            "tx_pkts": 0,
            "rx_bytes": 0,
            "rx_pkts": 0,
            "noise_floor": -95,
            "disabled": true,
            "usage": "24",
            "util_all": 0,
            "util_tx": 0,
            "util_rx_in_bss": 0,
            "util_rx_other_bss": 0,
            "util_unknown_wifi": 0,
            "util_non_wifi": 0,
            "util_undecodable_wifi": 0
        }